### PR TITLE
fix: sanitize cache tags to use valid HTTP header values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ public/images/og
 .vscode/
 # Local Netlify folder
 .netlify
+
+# Scratch folder
+/scratch

--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -1,7 +1,23 @@
 import { removeLastTrailingSlash } from 'lib/util';
 
+/**
+ * Creates a valid cache tag from a query string.
+ * Cache tags must be valid HTTP header values (no special characters like {, }, newlines).
+ */
+function createCacheTag(query) {
+  // Extract the operation name or first field from the query for a readable tag
+  const match = query.match(/(?:query|mutation)?\s*(\w+)|{\s*(\w+)/);
+  const identifier = match?.[1] || match?.[2] || 'gql';
+  // Create a simple hash of the query for uniqueness
+  const hash = query.split('').reduce((acc, char) => {
+    return ((acc << 5) - acc + char.charCodeAt(0)) | 0;
+  }, 0);
+  return `${identifier}-${Math.abs(hash)}`;
+}
+
 export async function gql({ query, variables, method = 'POST' }) {
   const url = removeLastTrailingSlash(process.env.WORDPRESS_GRAPHQL_ENDPOINT);
+  const cacheTag = createCacheTag(query);
   let data;
 
   if (method === 'POST') {
@@ -15,7 +31,7 @@ export async function gql({ query, variables, method = 'POST' }) {
         variables,
       }),
       next: {
-        tags: [query],
+        tags: [cacheTag],
       },
     }).then((r) => r.json());
   } else if (method === 'GET') {
@@ -28,7 +44,7 @@ export async function gql({ query, variables, method = 'POST' }) {
         'Content-Type': 'application/json',
       },
       next: {
-        tags: [query],
+        tags: [cacheTag],
       },
     }).then((r) => r.json());
   }


### PR DESCRIPTION
## Summary

- Fixes 502 error on `/sitemap.xml` in production
- Creates a helper function to generate valid cache tags from GraphQL queries

## Problem

The sitemap.xml was returning **502 Bad Gateway** errors on Netlify with:
```
TypeError: Headers.set: "{ generalSettings { description, language, title } }" is an invalid header value.
```

The `next.tags` cache option in `lib/request.js` was set to the raw GraphQL query string, which contains characters (`{`, `}`, newlines, commas) that are invalid in HTTP headers.

## Solution

Added a `createCacheTag()` helper that:
1. Extracts the operation name or first field from the query for readability
2. Creates a simple hash of the query for uniqueness
3. Combines them into a clean alphanumeric tag (e.g., `generalSettings-123456789`)

## Testing

- Build passes locally
- Sitemap generates correctly with proper XML output